### PR TITLE
docs: add CI and CodeQL badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![npm version](https://img.shields.io/npm/v/react-spec-gen)](https://www.npmjs.com/package/react-spec-gen)
 [![license](https://img.shields.io/npm/l/react-spec-gen)](./LICENSE)
 [![node](https://img.shields.io/node/v/react-spec-gen)](https://nodejs.org)
+[![CI](https://github.com/matieydjato/react-intel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/matieydjato/react-intel/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/matieydjato/react-intel/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/matieydjato/react-intel/security/code-scanning)
 
 Run it on a `.tsx` component — get a Vitest test file and a Storybook story file written next to the source.
 


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for local dev setup. -->

## Summary

Add CI and CodeQL status badges to the README so visitors can see build health and security scan status at a glance.

## Related issue

N/A

## Changes

- Add CI workflow status badge (Actions / ci.yml)
- Add CodeQL code scanning status badge

## Checklist

- [x] Tests added or updated _(N/A — docs-only change)_
- [x] `npm test` passes locally
- [x] `npm run typecheck` passes locally
- [ ] CHANGELOG entry added under `[Unreleased]` if user-visible _(N/A — README only)_
- [x] Docs updated (README / CONTRIBUTING) if behavior changed