### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Node ${{ matrix.node }} / ${{ matrix.os }})


### PR DESCRIPTION
Potential fix for [https://github.com/matieydjato/react-intel/security/code-scanning/3](https://github.com/matieydjato/react-intel/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml` so it applies to both jobs (`test` and `pack-smoke`) without changing current behavior.  
The best minimal fix is:

- `permissions:`
  - `contents: read`

Place it after the `concurrency` block (or near the top-level keys before `jobs`) so the scope is clear and inherited by all jobs. No imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to apply workflow-wide permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->