### PR TITLE
ci: target dependabot at develop, run CI on develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -20,6 +21,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for local dev setup. -->

## Summary

Switch to a `develop` → `main` GitFlow workflow. Dependabot will now open PRs against `develop`, and CI runs on both `main` and `develop` branches.

## Related issue

N/A

## Changes

- Add `target-branch: "develop"` to both Dependabot ecosystems (npm + github-actions)
- Run CI workflow on push/pull_request for `develop` in addition to `main`

## Checklist

- [x] Tests added or updated _(N/A — config-only change)_
- [x] `npm test` passes locally
- [x] `npm run typecheck` passes locally
- [ ] CHANGELOG entry added under `[Unreleased]` if user-visible _(N/A — internal CI/repo config)_
- [x] Docs updated (README / CONTRIBUTING) if behavior changed _(CONTRIBUTING update to follow in a separate PR)_