### PR TITLE
chore(lint): adopt Biome for lint + format with CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint (Biome)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Biome check
+        run: npm run lint
+
   test:
     name: Test (Node ${{ matrix.node }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/bin/react-intel.ts
+++ b/bin/react-intel.ts
@@ -1,6 +1,8 @@
 import { buildProgram } from "../src/cli/index.js";
 
-buildProgram().parseAsync(process.argv).catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+buildProgram()
+  .parseAsync(process.argv)
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/dist",
+      "!**/coverage",
+      "!**/node_modules",
+      "!tests/fixtures",
+      "!docs",
+      "!**/*.md"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "off",
+        "useImportType": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn"
+      },
+      "complexity": {
+        "noForEach": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "enabled": true,
+      "indentStyle": "space",
+      "indentWidth": 2
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-spec-gen": "dist/bin/react-intel.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.4.14",
         "@types/babel__traverse": "^7.20.5",
         "@types/node": "^25.6.0",
         "@types/prompts": "^2.4.9",
@@ -158,6 +159,169 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.14",
+        "@biomejs/cli-darwin-x64": "2.4.14",
+        "@biomejs/cli-linux-arm64": "2.4.14",
+        "@biomejs/cli-linux-arm64-musl": "2.4.14",
+        "@biomejs/cli-linux-x64": "2.4.14",
+        "@biomejs/cli-linux-x64-musl": "2.4.14",
+        "@biomejs/cli-win32-arm64": "2.4.14",
+        "@biomejs/cli-win32-x64": "2.4.14"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
+      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
+      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
+      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
+      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
+      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
+      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
+      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
+      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
+    "lint": "biome check",
+    "lint:fix": "biome check --write",
+    "format": "biome format --write",
     "start": "node dist/bin/react-intel.js",
-    "prepublishOnly": "npm run typecheck && npm test && npm run build"
+    "prepublishOnly": "npm run lint && npm run typecheck && npm test && npm run build"
   },
   "keywords": [
     "react",
@@ -61,6 +64,7 @@
     "prompts": "^2.4.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.14",
     "@types/babel__traverse": "^7.20.5",
     "@types/node": "^25.6.0",
     "@types/prompts": "^2.4.9",

--- a/src/ai/enhancer.ts
+++ b/src/ai/enhancer.ts
@@ -1,5 +1,5 @@
-import type { Enhancer } from "../core/pipeline.js";
 import type { ComponentModel } from "../core/model.js";
+import type { Enhancer } from "../core/pipeline.js";
 import type { AiProvider } from "./types.js";
 import { applySuggestion, validateSuggestion } from "./validate.js";
 

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,4 +1,4 @@
-export { buildEnhancer } from "./enhancer.js";
 export type { EnhancerOptions } from "./enhancer.js";
-export type { AiProvider, AiSuggestion } from "./types.js";
+export { buildEnhancer } from "./enhancer.js";
 export { MockProvider } from "./providers/mock.js";
+export type { AiProvider, AiSuggestion } from "./types.js";

--- a/src/ai/validate.ts
+++ b/src/ai/validate.ts
@@ -1,5 +1,5 @@
-import type { AiSuggestion } from "./types.js";
 import type { ComponentModel, EdgeCase, InferredValue } from "../core/model.js";
+import type { AiSuggestion } from "./types.js";
 
 /**
  * Validate a raw AiSuggestion against the analyzer-extracted ComponentModel.

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -1,9 +1,9 @@
 import ora from "ora";
-import { run } from "../../core/pipeline.js";
-import { ReactIntelError } from "../../core/errors.js";
 import { buildEnhancer, MockProvider } from "../../ai/index.js";
-import type { Enhancer } from "../../core/pipeline.js";
+import { ReactIntelError } from "../../core/errors.js";
 import type { ComponentModel } from "../../core/model.js";
+import type { Enhancer } from "../../core/pipeline.js";
+import { run } from "../../core/pipeline.js";
 import { fileExists, writeFileSafe } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";
 import { confirmOverwrite } from "../prompts.js";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { runGenerate } from "./commands/generate.js";
 import pkg from "../../package.json" with { type: "json" };
+import { runGenerate } from "./commands/generate.js";
 
 export function buildProgram(): Command {
   const program = new Command();

--- a/src/core/analyzer/component.ts
+++ b/src/core/analyzer/component.ts
@@ -1,6 +1,6 @@
+import { basename, extname } from "node:path";
 import _traverse from "@babel/traverse";
 import * as t from "@babel/types";
-import { basename, extname } from "node:path";
 import { AnalysisError } from "../errors.js";
 import type { ParsedSource } from "./parser.js";
 
@@ -51,7 +51,13 @@ export function findComponent(parsed: ParsedSource): ComponentInfo {
     ExportDefaultDeclaration(path) {
       const decl = path.node.declaration;
       // `export default function Foo() {}` / `export default () => ...`
-      const direct = nodeToComponent(decl, inferNameFromFile(parsed.filePath), true, undefined, declarations);
+      const direct = nodeToComponent(
+        decl,
+        inferNameFromFile(parsed.filePath),
+        true,
+        undefined,
+        declarations,
+      );
       if (direct) {
         defaultCandidate = direct;
         return;
@@ -66,7 +72,13 @@ export function findComponent(parsed: ParsedSource): ComponentInfo {
       }
       // `export default memo(Foo)` / `export default forwardRef(...)`
       if (t.isCallExpression(decl)) {
-        const info = nodeToComponent(decl, inferNameFromFile(parsed.filePath), true, undefined, declarations);
+        const info = nodeToComponent(
+          decl,
+          inferNameFromFile(parsed.filePath),
+          true,
+          undefined,
+          declarations,
+        );
         if (info) defaultCandidate = info;
       }
     },
@@ -83,7 +95,13 @@ export function findComponent(parsed: ParsedSource): ComponentInfo {
       if (t.isVariableDeclaration(decl)) {
         for (const declarator of decl.declarations) {
           if (!t.isIdentifier(declarator.id) || !declarator.init) continue;
-          const info = nodeToComponent(declarator.init, declarator.id.name, false, declarator.id, declarations);
+          const info = nodeToComponent(
+            declarator.init,
+            declarator.id.name,
+            false,
+            declarator.id,
+            declarations,
+          );
           if (info && !namedCandidate) namedCandidate = info;
         }
       }
@@ -137,7 +155,9 @@ function nodeToComponent(
       isDefaultExport,
       propsTypeName:
         extractPropsTypeFromParam(node.params[0]) ??
-        (t.isTSTypeAnnotation(idAnnotation) ? extractPropsTypeFromAnnotation(idAnnotation) : undefined),
+        (t.isTSTypeAnnotation(idAnnotation)
+          ? extractPropsTypeFromAnnotation(idAnnotation)
+          : undefined),
       implementation: node,
     };
   }

--- a/src/core/analyzer/parser.ts
+++ b/src/core/analyzer/parser.ts
@@ -1,6 +1,6 @@
-import { parse, type ParserOptions } from "@babel/parser";
-import type { File } from "@babel/types";
 import { readFile } from "node:fs/promises";
+import { type ParserOptions, parse } from "@babel/parser";
+import type { File } from "@babel/types";
 import { ParseError } from "../errors.js";
 
 const DEFAULT_PLUGINS: ParserOptions["plugins"] = [
@@ -21,7 +21,7 @@ export async function parseFile(filePath: string): Promise<ParsedSource> {
   let source: string;
   try {
     source = await readFile(filePath, "utf8");
-  } catch (err) {
+  } catch (_err) {
     throw new ParseError(
       `Could not read file: ${filePath}`,
       "Verify the path exists and is readable.",

--- a/src/core/analyzer/props.ts
+++ b/src/core/analyzer/props.ts
@@ -1,8 +1,8 @@
 import _traverse from "@babel/traverse";
 import * as t from "@babel/types";
 import type { PropDescriptor, PropKind } from "../model.js";
-import type { ParsedSource } from "./parser.js";
 import type { ComponentInfo } from "./component.js";
+import type { ParsedSource } from "./parser.js";
 
 const traverse = (_traverse as unknown as { default: typeof _traverse }).default ?? _traverse;
 
@@ -147,7 +147,11 @@ function collectMembersFromType(
 // ---------------------------------------------------------------------------
 
 type FoundType =
-  | { kind: "interface"; body: t.TSInterfaceBody; extends?: t.TSExpressionWithTypeArguments[] | null }
+  | {
+      kind: "interface";
+      body: t.TSInterfaceBody;
+      extends?: t.TSExpressionWithTypeArguments[] | null;
+    }
   | { kind: "alias"; value: t.TSType };
 
 function findTypeDeclaration(parsed: ParsedSource, name: string): FoundType | undefined {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -3,7 +3,10 @@
  */
 
 export class ReactIntelError extends Error {
-  constructor(message: string, public readonly hint?: string) {
+  constructor(
+    message: string,
+    public readonly hint?: string,
+  ) {
     super(message);
     this.name = "ReactIntelError";
   }

--- a/src/core/generator/story.ts
+++ b/src/core/generator/story.ts
@@ -40,15 +40,13 @@ type Story = StoryObj<typeof ${model.name}>;
 export const Default: Story = {
   args: ${defaultArgs},
 };
-${variantBlocks ? "\n" + variantBlocks + "\n" : ""}`;
+${variantBlocks ? `\n${variantBlocks}\n` : ""}`;
 }
 
 function renderArgs(inferred: Record<string, InferredValue>): string {
   const entries = Object.entries(inferred);
   if (entries.length === 0) return "{}";
-  const lines = entries
-    .map(([k, v]) => `    ${k}: ${storyExpression(v.expression)},`)
-    .join("\n");
+  const lines = entries.map(([k, v]) => `    ${k}: ${storyExpression(v.expression)},`).join("\n");
   return `{\n${lines}\n  }`;
 }
 

--- a/src/core/generator/test.ts
+++ b/src/core/generator/test.ts
@@ -31,7 +31,7 @@ ${hasProps ? `  const baseProps = ${baseProps};\n\n` : ""}  it("renders with def
     ${baseRender}
     ${rootAssertion}
   });
-${edgeCaseBlocks ? "\n" + edgeCaseBlocks + "\n" : ""}});
+${edgeCaseBlocks ? `\n${edgeCaseBlocks}\n` : ""}});
 `;
 }
 

--- a/src/core/intelligence/prop-inference.ts
+++ b/src/core/intelligence/prop-inference.ts
@@ -31,7 +31,6 @@ export function inferValue(prop: PropDescriptor): InferredValue {
       return { expression: "[]", label: "empty-array" };
     case "object":
       return { expression: "{}", label: "empty-object" };
-    case "unknown":
     default:
       return { expression: "undefined", label: "unknown" };
   }

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,12 +1,12 @@
 import { basename, dirname, extname, resolve } from "node:path";
-import { parseFile } from "./analyzer/parser.js";
 import { findComponent } from "./analyzer/component.js";
-import { extractProps } from "./analyzer/props.js";
 import { findRootJsx } from "./analyzer/jsx.js";
-import { inferAll } from "./intelligence/prop-inference.js";
-import { detectEdgeCases } from "./intelligence/edge-cases.js";
-import { generateTest } from "./generator/test.js";
+import { parseFile } from "./analyzer/parser.js";
+import { extractProps } from "./analyzer/props.js";
 import { generateStory } from "./generator/story.js";
+import { generateTest } from "./generator/test.js";
+import { detectEdgeCases } from "./intelligence/edge-cases.js";
+import { inferAll } from "./intelligence/prop-inference.js";
 import type { ComponentModel } from "./model.js";
 
 /** Optional async enhancer (e.g. AI). Receives the model, returns an enriched one. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,23 +2,23 @@
  * Public programmatic API. Stable surface for future consumers
  * (VS Code extension, batch tools, custom integrations).
  */
-export { run } from "./core/pipeline.js";
-export type { PipelineOptions, PipelineResult, Enhancer } from "./core/pipeline.js";
-export type {
-  ComponentModel,
-  PropDescriptor,
-  PropKind,
-  InferredValue,
-  EdgeCase,
-} from "./core/model.js";
+
+export type { AiProvider, AiSuggestion, EnhancerOptions } from "./ai/index.js";
+// AI layer — kept additive per FR-26.
+export { buildEnhancer, MockProvider } from "./ai/index.js";
 export {
-  ReactIntelError,
-  ParseError,
   AnalysisError,
   GenerationError,
   IOError,
+  ParseError,
+  ReactIntelError,
 } from "./core/errors.js";
-
-// AI layer — kept additive per FR-26.
-export { buildEnhancer, MockProvider } from "./ai/index.js";
-export type { AiProvider, AiSuggestion, EnhancerOptions } from "./ai/index.js";
+export type {
+  ComponentModel,
+  EdgeCase,
+  InferredValue,
+  PropDescriptor,
+  PropKind,
+} from "./core/model.js";
+export type { Enhancer, PipelineOptions, PipelineResult } from "./core/pipeline.js";
+export { run } from "./core/pipeline.js";

--- a/tests/ai/enhancer.test.ts
+++ b/tests/ai/enhancer.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
-import { run } from "../../src/core/pipeline.js";
-import { buildEnhancer, MockProvider } from "../../src/ai/index.js";
+import { describe, expect, it } from "vitest";
 import type { AiProvider } from "../../src/ai/index.js";
-import type { ComponentModel } from "../../src/core/model.js";
+import { buildEnhancer, MockProvider } from "../../src/ai/index.js";
+import { run } from "../../src/core/pipeline.js";
 
 const fixture = (name: string) => resolve(__dirname, `../fixtures/${name}`);
 
@@ -93,6 +92,7 @@ describe("ai/enhancer — orchestration safety", () => {
   it("ignores a non-object response without throwing", async () => {
     const garbage: AiProvider = {
       name: "garbage",
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately returning a non-object to test the guard
       async suggest(): Promise<any> {
         return "not an object";
       },

--- a/tests/analyzer/fixtures.test.ts
+++ b/tests/analyzer/fixtures.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 import { run } from "../../src/core/pipeline.js";
 
 const fixture = (name: string) => resolve(__dirname, `../fixtures/${name}`);

--- a/tests/analyzer/hoc.test.ts
+++ b/tests/analyzer/hoc.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 import { run } from "../../src/core/pipeline.js";
 
 const fixture = (name: string) => resolve(__dirname, `../fixtures/${name}`);
@@ -25,6 +25,6 @@ describe("analyzer — HOC unwrapping", () => {
   it("renders a meaningful test for a forwardRef component", async () => {
     const { outputs } = await run(fixture("IconButton.tsx"));
     expect(outputs.testSource).toContain("import { IconButton }");
-    expect(outputs.testSource).toContain("getByRole(\"button\")");
+    expect(outputs.testSource).toContain('getByRole("button")');
   });
 });

--- a/tests/analyzer/inheritance.test.ts
+++ b/tests/analyzer/inheritance.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 import { run } from "../../src/core/pipeline.js";
 
 const fixture = (name: string) => resolve(__dirname, `../fixtures/${name}`);
@@ -42,8 +42,8 @@ describe("analyzer — external/unsupported extends", () => {
     // The local-only prop must still be picked up.
     expect(model.props.some((p) => p.name === "label")).toBe(true);
     // And we should warn that React.AnchorHTMLAttributes can't be resolved.
-    expect(model.warnings.some((w) => /Cross-file type resolution|AnchorHTMLAttributes/.test(w))).toBe(
-      true,
-    );
+    expect(
+      model.warnings.some((w) => /Cross-file type resolution|AnchorHTMLAttributes/.test(w)),
+    ).toBe(true);
   });
 });

--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 import { run } from "../../src/core/pipeline.js";
 
 const FIXTURE = resolve(__dirname, "../fixtures/Button.tsx");

--- a/tests/generator/assertions.test.ts
+++ b/tests/generator/assertions.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 import { run } from "../../src/core/pipeline.js";
 
 const fixture = (name: string) => resolve(__dirname, `../fixtures/${name}`);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    "index": "src/index.ts",
+    index: "src/index.ts",
     "bin/react-intel": "bin/react-intel.ts",
   },
   format: ["esm"],
@@ -13,7 +13,7 @@ export default defineConfig({
   sourcemap: true,
   splitting: false,
   shims: false,
-  banner: ({ format }) => {
+  banner: () => {
     // tsup doesn't auto-add a shebang; we add it for the CLI bin only via esbuild.
     return {};
   },


### PR DESCRIPTION
## Summary

Adopt [Biome](https://biomejs.dev/) for linting + formatting with a CI gate. Single tool, zero plugins, sub-100ms checks. Replaces the absence of any lint/format guard.

## Related issue

N/A (audit-driven cleanup)

## Changes

- Add `@biomejs/biome` 2.4.14 as a dev dependency (pinned)
- Add `biome.json` with project conventions (2-space, double quotes, 100 cols, trailing commas, organize imports)
- Excludes: `dist`, `coverage`, `tests/fixtures` (deliberately weird code), `docs`, markdown
- Apply auto-fixes across `src/` and `tests/`: formatting, import organization, `useTemplate`, `noUselessSwitchCase`, `noUnusedImports`
- Add npm scripts: `lint`, `lint:fix`, `format`
- `prepublishOnly` now runs `lint` first
- New `lint` job in CI workflow (parallel to `test`)

## Validation

- `npm run lint` → 0 errors, 0 warnings
- `npm run typecheck` → OK
- `npm test` → 36/36 pass
- `npm run build` → OK

## Checklist

- [x] Tests added or updated *(no new tests; mechanical lint adoption only)*
- [x] `npm test` passes locally
- [x] `npm run typecheck` passes locally
- [ ] CHANGELOG entry *(internal tooling, not user-visible)*
- [ ] Docs updated *(no behavior change)*