### PR TITLE
test(cli): add tests for runGenerate command

### DIFF
--- a/tests/cli/generate.test.ts
+++ b/tests/cli/generate.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the prompts module BEFORE importing the CLI command.
+const promptsMock = vi.fn();
+vi.mock("prompts", () => ({
+  default: (...args: unknown[]) => promptsMock(...args),
+}));
+
+const { runGenerate } = await import("../../src/cli/commands/generate.js");
+
+const BUTTON_FIXTURE = resolve(__dirname, "../fixtures/Button.tsx");
+
+let workdir: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "react-intel-cli-"));
+  promptsMock.mockReset();
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function copyFixture(name = "Button.tsx"): Promise<string> {
+  const src = await readFile(BUTTON_FIXTURE, "utf8");
+  const target = join(workdir, name);
+  await writeFile(target, src, "utf8");
+  return target;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("runGenerate (CLI command)", () => {
+  it("writes test and story files for a valid component (happy path)", async () => {
+    const file = await copyFixture();
+
+    const code = await runGenerate(file, { ai: false, yes: true });
+
+    expect(code).toBe(0);
+    expect(await exists(join(workdir, "Button.test.tsx"))).toBe(true);
+    expect(await exists(join(workdir, "Button.stories.tsx"))).toBe(true);
+    expect(promptsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 1 and prints a friendly error when the file does not exist", async () => {
+    const code = await runGenerate(join(workdir, "DoesNotExist.tsx"), {
+      ai: false,
+      yes: true,
+    });
+
+    expect(code).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
+    const errorOutput = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(errorOutput.toLowerCase()).toMatch(/not found|enoent|cannot|could not|failed/);
+  });
+
+  it("overwrites without prompting when --yes is set, even if files exist", async () => {
+    const file = await copyFixture();
+    // Pre-create the targets so the overwrite path is exercised.
+    await writeFile(join(workdir, "Button.test.tsx"), "// stale\n", "utf8");
+    await writeFile(join(workdir, "Button.stories.tsx"), "// stale\n", "utf8");
+
+    const code = await runGenerate(file, { ai: false, yes: true });
+
+    expect(code).toBe(0);
+    expect(promptsMock).not.toHaveBeenCalled();
+    const test = await readFile(join(workdir, "Button.test.tsx"), "utf8");
+    const story = await readFile(join(workdir, "Button.stories.tsx"), "utf8");
+    expect(test).not.toBe("// stale\n");
+    expect(story).not.toBe("// stale\n");
+  });
+
+  it("prompts and skips files when the user declines overwrite", async () => {
+    const file = await copyFixture();
+    await writeFile(join(workdir, "Button.test.tsx"), "// keep me\n", "utf8");
+    await writeFile(join(workdir, "Button.stories.tsx"), "// keep me\n", "utf8");
+    promptsMock.mockResolvedValue({ ok: false });
+
+    const code = await runGenerate(file, { ai: false, yes: false });
+
+    expect(code).toBe(0);
+    expect(promptsMock).toHaveBeenCalledTimes(2);
+    const test = await readFile(join(workdir, "Button.test.tsx"), "utf8");
+    const story = await readFile(join(workdir, "Button.stories.tsx"), "utf8");
+    expect(test).toBe("// keep me\n");
+    expect(story).toBe("// keep me\n");
+  });
+
+  it("prompts and overwrites when the user confirms", async () => {
+    const file = await copyFixture();
+    await writeFile(join(workdir, "Button.test.tsx"), "// stale\n", "utf8");
+    await writeFile(join(workdir, "Button.stories.tsx"), "// stale\n", "utf8");
+    promptsMock.mockResolvedValue({ ok: true });
+
+    const code = await runGenerate(file, { ai: false, yes: false });
+
+    expect(code).toBe(0);
+    expect(promptsMock).toHaveBeenCalledTimes(2);
+    const test = await readFile(join(workdir, "Button.test.tsx"), "utf8");
+    expect(test).not.toBe("// stale\n");
+  });
+
+  it("runs the AI enhancer path without throwing when --ai is set", async () => {
+    const file = await copyFixture();
+
+    const code = await runGenerate(file, { ai: true, yes: true });
+
+    expect(code).toBe(0);
+    expect(await exists(join(workdir, "Button.test.tsx"))).toBe(true);
+  });
+});

--- a/tests/cli/generate.test.ts
+++ b/tests/cli/generate.test.ts
@@ -69,7 +69,7 @@ describe("runGenerate (CLI command)", () => {
 
     expect(code).toBe(1);
     expect(errorSpy).toHaveBeenCalled();
-    const errorOutput = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    const errorOutput = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(errorOutput.toLowerCase()).toMatch(/not found|enoent|cannot|could not|failed/);
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         "src/**/*.d.ts",
         "src/**/index.ts",
         "src/**/types.ts",
-        "src/cli/**",
+        "src/cli/prompts.ts",
         "src/utils/**",
         "src/core/errors.ts",
         "src/core/model.ts",


### PR DESCRIPTION
## Summary

Add unit tests for the `runGenerate` CLI command — the previously-untested entry point that orchestrates pipeline + file writes + interactive prompts. Closes the most critical gap from the audit (TOP1: CLI command had zero tests).

## Related issue

N/A (audit-driven cleanup)

## Changes

- Add `tests/cli/generate.test.ts` (6 tests):
  1. **Happy path** — generates `*.test.tsx` and `*.stories.tsx` from a valid component
  2. **Missing file** — returns exit code 1 and prints a friendly error
  3. **`--yes` flag** — overwrites existing files without prompting
  4. **Prompt declined** — preserves existing files when user says no
  5. **Prompt accepted** — overwrites when user confirms
  6. **`--ai` flag** — runs the enhancer path (mock provider) without throwing
- `prompts` module is mocked via `vi.mock`; file I/O happens in real `mkdtemp` workdirs
- Re-enable coverage measurement on `src/cli/commands/**` (only `prompts.ts` remains excluded)

## Validation

- `npm test` → **42/42** pass (was 36/36)
- `npm run lint` → 0 issues
- `npm run typecheck` → OK
- `npm run test:coverage` → all thresholds still met

## Checklist

- [x] Tests added or updated
- [x] `npm test` passes locally
- [x] `npm run typecheck` passes locally
- [ ] CHANGELOG entry *(internal test additions only)*
- [ ] Docs updated *(no behavior change)*